### PR TITLE
Warm up solver lambda on page load to prevent cold start delay

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -296,4 +296,22 @@ function reset() {
     createNewRow(board, "RAISE", animate=true);
 }
 
+/* When the solver lambda function is not invoked for 5 minutes or more, it 
+requires a cold start which causes ~1s of latency. This function sends an empty
+request to the warm up the lamda and prevent a cold start. It is meant to be called
+when the webpage loads. */ 
+function warmupLambda(){
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", "https://br7gxujg3p2vooleijh7nuwq2u0tpggb.lambda-url.us-east-1.on.aws/");
+    xhr.setRequestHeader("Content-Type", "application/json; charset=UTF-8")
+    xhr.onload = () => {
+    if (xhr.readyState != 4 || xhr.status != 200) {
+        console.log(`Error: ${xhr.status}`);
+        error = JSON.parse(xhr.responseText);
+    }
+    };
+    xhr.send();
+}
+
+warmupLambda();
 reset();


### PR DESCRIPTION
First off, this is such a cool tool! Thanks for making it!

When I used your website for the first time, I noticed that the tool was slow to provide the first guess but quick for subsequent guesses. When I ran the tool again, it was fast from the start. I see that you are using a lambda function under the hood which requires a [cold start](https://aws.amazon.com/blogs/compute/operating-lambda-performance-optimization-part-1/) after ~5 min of inactivity, resulting in ~1s of latency. 

This PR is to add and call the method `warmupLambda` which invokes the lambda with a blank request on page load.  This will give the solver time to warm up while the user enters the results of the first guess.